### PR TITLE
Add JPEG Codec Support

### DIFF
--- a/gdal-configure.opt
+++ b/gdal-configure.opt
@@ -19,7 +19,7 @@ A += --without-dds
 A += --without-gta
 A += --with-libtiff=internal
 A += --with-geotiff=internal
-A += --without-jpeg
+A += --with-jpeg=internal
 A += --without-jpeg12
 A += --without-gif
 A += --without-ogdi


### PR DESCRIPTION
This PR adjusts the compilation options to include internal JPEG support so that gdal-js can read/write tiffs compressed with the JPEG option.