### PR TITLE
Export more gdal methods around rasterization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ EXPORTED_FUNCTIONS = "[\
   '_GDALSetCacheMax',\
   '_GDALAllRegister',\
   '_GDALOpen',\
+  '_GDALOpenEx',\
   '_GDALClose',\
   '_GDALGetDriverByName',\
   '_GDALCreate',\
@@ -56,7 +57,13 @@ EXPORTED_FUNCTIONS = "[\
   '_CPLErrorReset',\
   '_CPLGetLastErrorMsg',\
   '_CPLGetLastErrorNo',\
-  '_CPLGetLastErrorType'\
+  '_CPLGetLastErrorType',\
+  '_GDALRasterize',\
+  '_GDALRasterizeOptionsNew',\
+  '_GDALRasterizeOptionsFree',\
+  '_GDALDEMProcessing',\
+  '_GDALDEMProcessingOptionsNew',\
+  '_GDALDEMProcessingOptionsFree'\
 ]"
 
 export EMCONFIGURE_JS

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This library exports the following GDAL functions:
 - GDALSetCacheMax
 - GDALAllRegister
 - GDALOpen
+- GDALOpenEx
 - GDALClose
 - GDALGetDriverByName
 - GDALCreate
@@ -68,6 +69,12 @@ This library exports the following GDAL functions:
 - CPLGetLastErrorMsg
 - CPLGetLastErrorNo
 - CPLGetLastErrorType
+- GDALRasterize
+- GDALRasterizeOptionsNew
+- GDALRasterizeOptionsFree
+- GDALDEMProcessing
+- GDALDEMProcessingOptionsNew
+- GDALDEMProcessingOptionsFree
 
 For documentation of these functions' behavior, please see the
 [GDAL documentation](http://www.gdal.org/gdal_8h.html)


### PR DESCRIPTION
Exports additional functions:
- `GDALOpenEx` for opening non-raster files
- `GDALRasterize` and related
- `GDALDemProcessing` and related

I don't know of a good way to test this other than verifying that the build completes.