### PR TITLE
Export RasterIO functions and fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /opt/emsdk
 # In that case, replace "latest" below with "${EMSCRIPTEN_V}".
 ARG EMSCRIPTEN_V
 
-RUN ./emsdk install latest
-RUN ./emsdk activate latest
+RUN ./emsdk install ${EMSCRIPTEN_V}
+RUN ./emsdk activate ${EMSCRIPTEN_V}
 
 RUN git config --global user.name 'Nobody'
 RUN git config --global user.email 'nobody@nowhere.nope'
@@ -35,5 +35,6 @@ COPY entrypoint.sh .
 RUN chmod +x entrypoint.sh
 
 WORKDIR /opt/gdaljs
+RUN git config --global --add safe.directory /opt/gdaljs
 
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ EXPORTED_FUNCTIONS = "[\
   '_GDALGetRasterMinimum',\
   '_GDALGetRasterMaximum',\
   '_GDALGetRasterNoDataValue',\
+  '_GDALRasterIO',\
+  '_GDALRasterIOEx',\
   '_GDALGetProjectionRef',\
   '_GDALSetProjection',\
   '_GDALGetGeoTransform',\
@@ -71,6 +73,8 @@ EXPORTED_FUNCTIONS = "[\
   '_GDALDatasetGetLayerByName',\
   '_GDALDatasetGetLayerCount',\
   '_GDALDatasetExecuteSQL',\
+  '_GDALDatasetRasterIO',\
+  '_GDALDatasetRasterIOEx',\
   '_OGR_L_GetNextFeature',\
   '_OGR_L_GetExtent',\
   '_OGR_L_GetLayerDefn',\

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,5 +4,7 @@ set -e
 
 DIR="$(dirname "$0")"
 
+# Pin to emsdk 3.1.21. Higher versions seem to switch to C++17 by default, which GDAL 2.4 isn't
+# compatible with.
 docker build -t gdaljs-build "${DIR}/.." \
-    --build-arg EMSCRIPTEN_V=3.1.18
+    --build-arg EMSCRIPTEN_V=3.1.21


### PR DESCRIPTION
- Exports the RasterIO functions, which were not yet exported.
- Resolves #44 

There aren't examples associated with RasterIO so there's nothing new to test here.